### PR TITLE
use geometry svc in reco of MC samples; cleanup printout in reco algo…

### DIFF
--- a/PadmeReco/EVeto/include/EVetoReconstruction.hh
+++ b/PadmeReco/EVeto/include/EVetoReconstruction.hh
@@ -19,8 +19,8 @@ public:
 
   // void ParseConfFile(TString);
   // virtual void Init(PadmeVReconstruction*);
-  virtual void ProcessEvent(TMCVEvent*,TMCEvent*);
-  //virtual void EndProcessing();
+  // virtual void ProcessEvent(TMCVEvent*,TMCEvent*);
+  // virtual void EndProcessing();
   virtual void HistoInit();
   virtual void AnalyzeEvent(TRawEvent* evt);
 

--- a/PadmeReco/EVeto/src/EVetoReconstruction.cc
+++ b/PadmeReco/EVeto/src/EVetoReconstruction.cc
@@ -91,9 +91,12 @@ TRecoVEvent * EVetoReconstruction::ProcessEvent(TDetectorVEvent* tEvent, Event* 
   return fRecoEvent;
 }
 */
+
+/* this was just for debugging via printout 
 void EVetoReconstruction::ProcessEvent(TMCVEvent* tEvent, TMCEvent* tMCEvent)
 {
   PadmeVReconstruction::ProcessEvent(tEvent,tMCEvent);
+
   TEVetoMCEvent* tEVetoEvent = (TEVetoMCEvent*)tEvent;
   std::cout << "--- EVetoReconstruction --- run/event/#hits/#digi " << tEVetoEvent->GetRunNumber() << " " << tEVetoEvent->GetEventNumber() << " " << tEVetoEvent->GetNHits() << " " << tEVetoEvent->GetNDigi() << std::endl;
   for (Int_t iH=0; iH<tEVetoEvent->GetNHits(); iH++) {
@@ -105,6 +108,7 @@ void EVetoReconstruction::ProcessEvent(TMCVEvent* tEvent, TMCEvent* tMCEvent)
     digi->Print();
   }
 }
+*/
 
 // void EVetoReconstruction::EndProcessing()
 // {;}

--- a/PadmeReco/HEPVeto/include/HEPVetoReconstruction.hh
+++ b/PadmeReco/HEPVeto/include/HEPVetoReconstruction.hh
@@ -19,7 +19,7 @@ public:
 
   // void ParseConfFile(TString);
   // virtual void Init(PadmeVReconstruction*);
-  virtual void ProcessEvent(TMCVEvent*,TMCEvent*);
+  // virtual void ProcessEvent(TMCVEvent*,TMCEvent*);
   virtual void AnalyzeEvent(TRawEvent* rawEv);
   virtual void HistoInit();
   // virtual void EndProcessing();

--- a/PadmeReco/HEPVeto/src/HEPVetoReconstruction.cc
+++ b/PadmeReco/HEPVeto/src/HEPVetoReconstruction.cc
@@ -102,6 +102,8 @@ TRecoVEvent * HEPVetoReconstruction::ProcessEvent(TDetectorVEvent* tEvent, Event
   return fRecoEvent;
 }
 */
+
+/* for debugging only 
 void HEPVetoReconstruction::ProcessEvent(TMCVEvent* tEvent, TMCEvent* tMCEvent)
 {
   PadmeVReconstruction::ProcessEvent(tEvent,tMCEvent);
@@ -116,6 +118,7 @@ void HEPVetoReconstruction::ProcessEvent(TMCVEvent* tEvent, TMCEvent* tMCEvent)
     digi->Print();
   }
 }
+*/
 
 // void HEPVetoReconstruction::EndProcessing()
 // {;}

--- a/PadmeReco/PVeto/include/PVetoReconstruction.hh
+++ b/PadmeReco/PVeto/include/PVetoReconstruction.hh
@@ -16,7 +16,7 @@ public:
   
   PVetoReconstruction(TFile*, TString);
   ~PVetoReconstruction();
-  virtual void ProcessEvent(TMCVEvent*,TMCEvent*);
+  // virtual void ProcessEvent(TMCVEvent*,TMCEvent*);
   virtual void HistoInit();
   virtual void AnalyzeEvent(TRawEvent* evt);
 

--- a/PadmeReco/PVeto/src/PVetoReconstruction.cc
+++ b/PadmeReco/PVeto/src/PVetoReconstruction.cc
@@ -70,6 +70,7 @@ void PVetoReconstruction::HistoInit(){
 }
 
 
+/* only for debugging 
 void PVetoReconstruction::ProcessEvent(TMCVEvent* tEvent, TMCEvent* tMCEvent)
 {
   PadmeVReconstruction::ProcessEvent(tEvent,tMCEvent);
@@ -84,9 +85,8 @@ void PVetoReconstruction::ProcessEvent(TMCVEvent* tEvent, TMCEvent* tMCEvent)
     digi->Print();
   }
 
-  
-
 }
+*/
 
 
 

--- a/PadmeReco/RecoBase/src/PadmeVReconstruction.cc
+++ b/PadmeReco/RecoBase/src/PadmeVReconstruction.cc
@@ -140,6 +140,9 @@ void PadmeVReconstruction::ProcessEvent(TMCVEvent* tEvent,TMCEvent* tMCEvent) {
 
   // MC to reco hits
   ConvertMCDigitsToRecoHits(tEvent, tMCEvent);
+
+  if(fGeometry)           fGeometry->ComputePositions(GetRecoHits());
+
   // Clustering  
   ClearClusters();
   BuildClusters();

--- a/PadmeReco/SAC/include/SACReconstruction.hh
+++ b/PadmeReco/SAC/include/SACReconstruction.hh
@@ -21,7 +21,7 @@ public:
 
   // void ParseConfFile(TString);
   // virtual void Init(PadmeVReconstruction*);
-  virtual void ProcessEvent(TMCVEvent*,TMCEvent*);
+  // virtual void ProcessEvent(TMCVEvent*,TMCEvent*);
   // virtual void EndProcessing();
   virtual void HistoInit();
   virtual void AnalyzeEvent(TRawEvent* evt);

--- a/PadmeReco/SAC/src/SACReconstruction.cc
+++ b/PadmeReco/SAC/src/SACReconstruction.cc
@@ -153,6 +153,8 @@ TRecoVEvent * SACReconstruction::ProcessEvent(TDetectorVEvent* tEvent, Event* tG
   return fRecoEvent;
 }
 */
+
+/* only for debugging printout 
 void SACReconstruction::ProcessEvent(TMCVEvent* tEvent, TMCEvent* tMCEvent)
 {
   PadmeVReconstruction::ProcessEvent(tEvent,tMCEvent);
@@ -173,6 +175,7 @@ void SACReconstruction::ProcessEvent(TMCVEvent* tEvent, TMCEvent* tMCEvent)
     digi->Print();
   }
 }
+*/
 
 // void SACReconstruction::EndProcessing()
 // {;}

--- a/PadmeReco/Target/src/TargetReconstruction.cc
+++ b/PadmeReco/Target/src/TargetReconstruction.cc
@@ -184,7 +184,7 @@ void TargetReconstruction::ProcessEvent(TMCVEvent* tEvent, TMCEvent* tMCEvent)
    fHits.push_back(Hit);
   }
    
-   std::cout<< "size hit " << fHits.size() << " energia " <<  std::endl;
+  // std::cout<< "size hit " << fHits.size() << " energia " <<  std::endl;
   // set geometry 
   if(fGeometry)           fGeometry->ComputePositions(GetRecoHits());
   


### PR DESCRIPTION
fix: enable the use of the geometry svc for hits of all detectors for MC input data