### PR TITLE
Feature/p veto histos for debugging

### DIFF
--- a/PadmeReco/PVeto/include/PVetoReconstruction.hh
+++ b/PadmeReco/PVeto/include/PVetoReconstruction.hh
@@ -18,6 +18,7 @@ public:
   ~PVetoReconstruction();
   // virtual void ProcessEvent(TMCVEvent*,TMCEvent*);
   virtual void HistoInit();
+  void BuildHits(TRawEvent* rawEv);//Beth 1/8/19 copied from ECal to get board/channel info at digitizer level
   virtual void AnalyzeEvent(TRawEvent* evt);
 
 private:

--- a/PadmeReco/RecoBase/include/DigitizerChannelReco.hh
+++ b/PadmeReco/RecoBase/include/DigitizerChannelReco.hh
@@ -139,18 +139,10 @@ private:
 
   TH1F * hSignalTmp;
   TH1F * hdxdtTmp;
-
-  TH1F * hSignal[10];
-  TH1F * hSigFinal;
-  TH1F * hSignalSmooth[10];
-
-  TH1F * hdxdt[10];
   TH1F * hdxdtFinal;
-  TH1F * hdxdtSmooth[10];
 
-  TH1F * hDerivRatio[10];
-  TH1F * hDerivRatioSmooth[10];
-
+  TH1F * hSignal[96];
+  TH1F * hRCVoltage[96];
   TH1F * hPedSpectrum[96];
 
   TH1F * hAmpSpectrum[96];
@@ -164,13 +156,8 @@ private:
 
   TH1F * hdxdtMaxTime;
   TH1F * hSigMax;
-  TH1F * hRCVoltage[10];
+  TH1F * hSigFinal;
 
-  TH1F * hTrialSignal;
-  TH1F * hRCProcessedTrialSignal;
-  TH1F * hChargeInt;
-  TH1F * hChargeIntRC;
-  TH1F * hdxdtRMS;
   TH1F * hSat;
 
   TH1F * hSigOv;
@@ -184,7 +171,6 @@ private:
   // calc charge
   Double_t AbsSamRec[1024];
 
-  TList* hListCal; // single board related histograms 
   TList* hListWaveform; //Waveform histograms
   TList* hListAmp; //Amplitude spectra
   TList* hListPed; //Pedestal spectra
@@ -192,7 +178,6 @@ private:
   TList* hListAmpCharge2D; //2D amplitude/charge plots
   TList* hListTmp;  // More general histograms 
 
-  TList* hListCalRC; // single board related histograms 
   TList* hListWaveformRC; //Waveform histograms
   TList* hListAmpRC; //Amplitude spectra
   TList* hListPedRC; //Pedestal spectra

--- a/PadmeReco/RecoBase/include/DigitizerChannelReco.hh
+++ b/PadmeReco/RecoBase/include/DigitizerChannelReco.hh
@@ -4,8 +4,10 @@
 #include "TObject.h"
 #include "TVector3.h"
 #include "TH1D.h"
+#include "TH2D.h"
 #include "TFile.h"
 #include "TList.h"
+#include "TTree.h"
 
 typedef  GlobalRecoConfigOptions LocalRecoConfigOptions;
 
@@ -21,6 +23,13 @@ public:
   virtual void Init(PadmeVRecoConfig *cfg){return ;}
   virtual void Init(GlobalRecoConfigOptions *gOptions, PadmeVRecoConfig *cfg);
 
+  //Beth 7/6/19 copied from Mauro's DigitizerChannelECal structure to create a set of debug histograms that are produced only in debug mode
+  virtual void PrepareDebugHistos();
+  virtual void PrepareTmpHistos();
+  virtual void SaveDebugHistos();
+
+  void SetGlobalRunningMode(GlobalRecoConfigOptions* o){fGlobalMode = o;}
+  void SetLocalRunningMode(LocalRecoConfigOptions* o)  {fLocalMode  = o;}
   void ReconstructSingleHit(std::vector<TRecoVHit *> &hitArray);
   void ReconstructMultiHit (std::vector<TRecoVHit *> &hitArray);
   void PrintConfig();
@@ -32,10 +41,24 @@ public:
   Double_t CalcChaTime(std::vector<TRecoVHit *> &hitArray,UShort_t,UShort_t);
 
   Double_t ZSupHit(Float_t thr,UShort_t NAvg);  //M. Raggi 30/10/2018
+
   void DigitalProcessingRRC(Double_t *uin, Double_t *uout,int NPOINTS, Double_t timebin);
+  void HistoFill();//Beth 30/7/19 fills debugging histograms created in PrepareDebugHistos
 
   void SetAbsSignals();
+
+  Int_t GetChID(){return fChID;};
+  void  SetChID(Int_t ChID){fChID=ChID;};
   
+  Int_t GetElChID(){return fElChID;};
+  void  SetElChID(Int_t ChID){fElChID=ChID;};
+
+  Int_t GetBdID(){return fBdID;};
+  void  SetBdID(Int_t BdID){fBdID=BdID;};
+
+  Int_t GetTrigMask(){return fTrigMask;};
+  void  SetTrigMask(Int_t TrigMask){fTrigMask=TrigMask;};
+
 private:
   //What do we operate
   UShort_t fNSamples;
@@ -47,17 +70,20 @@ private:
   Double_t fTime;
   UShort_t fNPedSamples;
 
+  Int_t fChID;
+  Int_t fElChID;
+  Int_t fBdID;
+  Int_t fTrigMask;
+
   //Configuration variables
   Int_t fSignalWidth;
   Int_t fPreSamples;
   Int_t fPostSamples;
   Int_t fPedOffset; 
   Int_t fPedMaxNSamples;
+  Int_t fProcessing;
   
-  Int_t fMinAmplitude;
-
-  TH1D *H1;
-  
+  Int_t fMinAmplitude;  
 
   Double_t fSignalThreshold;
   Double_t fSignalPercentage;
@@ -65,21 +91,22 @@ private:
   Double_t fTimeBin;
   Double_t fVoltageBin;
   Double_t fImpedance;
-  Double_t fAmpli;
+  Double_t fAmpli1;
+  Double_t fAmpli2;
 
   Double_t fAmpThresholdLow;
   Double_t fAmpThresholdHigh;
 
-  Bool_t fMultihit;
   Bool_t fUseAbsSignals;
+  Bool_t fUseOverSample;
+
+  //Beth 30/7/19 to investigate different stages of improvement in reconstruction
+  Bool_t fNewPed;
+  Bool_t fTimeCut;
 
   //mode variables
   GlobalRecoConfigOptions* fGlobalMode;
   LocalRecoConfigOptions*  fLocalMode;
-
-  
-
-
 
   Int_t fUsePulseProcessing ;
   Int_t fPeakSearchWidth    ;
@@ -107,6 +134,72 @@ private:
   Short_t  GetMaximum(){return fMax;};
   Double_t GetPedestal(){return fPed;};
 
+  // Debug histogram structure
+  TFile * fileOut;
+
+  TH1F * hSignalTmp;
+  TH1F * hdxdtTmp;
+
+  TH1F * hSignal[10];
+  TH1F * hSigFinal;
+  TH1F * hSignalSmooth[10];
+
+  TH1F * hdxdt[10];
+  TH1F * hdxdtFinal;
+  TH1F * hdxdtSmooth[10];
+
+  TH1F * hDerivRatio[10];
+  TH1F * hDerivRatioSmooth[10];
+
+  TH1F * hPedSpectrum[96];
+
+  TH1F * hAmpSpectrum[96];
+  TH1F * hAmpChargeRatio[96];
+  TH2F * hAmpCharge2D[96];
+
+  TH1F * hAmpSpectrumRC[96];
+  TH1F * hAmpChargeRatioRC[96];
+  TH2F * hAmpCharge2DRC[96];
+
+
+  TH1F * hdxdtMaxTime;
+  TH1F * hSigMax;
+  TH1F * hRCVoltage[10];
+
+  TH1F * hTrialSignal;
+  TH1F * hRCProcessedTrialSignal;
+  TH1F * hChargeInt;
+  TH1F * hChargeIntRC;
+  TH1F * hdxdtRMS;
+  TH1F * hSat;
+
+  TH1F * hSigOv;
+  TH1F * hSigOvSm;
+  TH1F * hdxdtSigOvSm;
+
+  TH1D *  H1;
+  TH1D *  H2;
+  //  Int_t m;
+  Int_t ElCh;
+  // calc charge
+  Double_t AbsSamRec[1024];
+
+  TList* hListCal; // single board related histograms 
+  TList* hListWaveform; //Waveform histograms
+  TList* hListAmp; //Amplitude spectra
+  TList* hListPed; //Pedestal spectra
+  TList* hListAmpChargeRatio; //Spectra of ratio of amplitude to charge
+  TList* hListAmpCharge2D; //2D amplitude/charge plots
+  TList* hListTmp;  // More general histograms 
+
+  TList* hListCalRC; // single board related histograms 
+  TList* hListWaveformRC; //Waveform histograms
+  TList* hListAmpRC; //Amplitude spectra
+  TList* hListPedRC; //Pedestal spectra
+  TList* hListAmpChargeRatioRC; //Spectra of ratio of amplitude to charge
+  TList* hListAmpCharge2DRC; //2D amplitude/charge plots
+
+  TTree* Reco;
 
 };
 

--- a/PadmeReco/RecoBase/src/DigitizerChannelReco.cc
+++ b/PadmeReco/RecoBase/src/DigitizerChannelReco.cc
@@ -20,13 +20,11 @@ void DigitizerChannelReco::PrintConfig(){
   std::cout << "fUseAbsSignals: " << fUseAbsSignals << std::endl;  
 }
 
-
 DigitizerChannelReco::~DigitizerChannelReco(){
   if(fGlobalMode->IsPedestalMode() || fGlobalMode->GetGlobalDebugMode()){
     SaveDebugHistos();
   }
 ;}
-
 
 void DigitizerChannelReco::Init(GlobalRecoConfigOptions *gMode, PadmeVRecoConfig *cfg){
 

--- a/PadmeReco/RecoBase/src/DigitizerChannelReco.cc
+++ b/PadmeReco/RecoBase/src/DigitizerChannelReco.cc
@@ -16,6 +16,8 @@ int waveformhitmax=96;
 char name[256];
 char newname[256];
 
+TString detname;
+
 void DigitizerChannelReco::PrintConfig(){
   std::cout << "Signal width: " << fSignalWidth << " samples" << std::endl;
   std::cout << "fUseAbsSignals: " << fUseAbsSignals << std::endl;  
@@ -35,9 +37,12 @@ void DigitizerChannelReco::Init(GlobalRecoConfigOptions *gMode, PadmeVRecoConfig
   name += "DIGI";
   H1 = new TH1D(name.c_str(),name.c_str(),1000,0.,1000.);
   name = cfg->GetParOrDefault("DETECTOR","NAME","DIGI");
+
+  detname=name;//Get detector name in global variable to be used in fileoutname
+
   name += "2";
   H2 = new TH1D(name.c_str(),name.c_str(),990,0.,990.);
-    
+
   fTimeBin        = cfg->GetParOrDefault("ADC","TimeBin",1.);
   fVoltageBin     = cfg->GetParOrDefault("ADC","VoltageBin",0.000244);
   fImpedance      = cfg->GetParOrDefault("ADC","InputImpedance",50.);
@@ -86,18 +91,18 @@ void DigitizerChannelReco::Init(GlobalRecoConfigOptions *gMode, PadmeVRecoConfig
 
 void DigitizerChannelReco::PrepareDebugHistos(){ //Beth 7/6/19 copied from Mauro's DigitizerChannelECal structure to create a set of debug histograms that are produced only in debug mode
   
-  static char* fileoutname;
+  TString fileoutname;
   char name[256];
   char newname[256];
 
-  if(fProcessing==0&&fNewPed==0&&fTimeCut==0) fileoutname="RecoAnSingleHitOldPedNoTimeCut.root";
-  if(fProcessing==0&&fNewPed==1&&fTimeCut==0) fileoutname="RecoAnSingleHitNewPedNoTimeCut.root";
+  if(fProcessing==0&&fNewPed==0&&fTimeCut==0) fileoutname=detname+"RecoAnSingleHitOldPedNoTimeCut.root";
+  if(fProcessing==0&&fNewPed==1&&fTimeCut==0) fileoutname=detname+"RecoAnSingleHitNewPedNoTimeCut.root";
 
-  if(fProcessing==0&&fNewPed==0&&fTimeCut==1) fileoutname="RecoAnSingleHitOldPedTimeCut.root";
-  if(fProcessing==0&&fNewPed==1&&fTimeCut==1) fileoutname="RecoAnSingleHitNewPedTimeCut.root";
+  if(fProcessing==0&&fNewPed==0&&fTimeCut==1) fileoutname=detname+"RecoAnSingleHitOldPedTimeCut.root";
+  if(fProcessing==0&&fNewPed==1&&fTimeCut==1) fileoutname=detname+"RecoAnSingleHitNewPedTimeCut.root";
 
-  if(fProcessing==1) fileoutname="RecoAnMultiHit.root";
-  if(fProcessing==2) fileoutname="RecoAnRCProcessing.root";
+  if(fProcessing==1) fileoutname=detname+"RecoAnMultiHit.root";
+  if(fProcessing==2) fileoutname=detname+"RecoAnRCProcessing.root";
 
   std::cout<<"Created "<<fileoutname<<std::endl;
 
@@ -786,7 +791,7 @@ void DigitizerChannelReco::HistoFill(){
       }
     }
     
-    if(waveformhit==0) std::cout<<"parameters are: fProcessing = "<<fProcessing<<" fNewPed = "<<fNewPed<<" fTimeCut = "<<fTimeCut<<std::endl;
+    if(waveformhit==0) std::cout<<"parameters are: Detector = "<<detname<<" fProcessing = "<<fProcessing<<" fNewPed = "<<fNewPed<<" fTimeCut = "<<fTimeCut<<std::endl;
     waveformhit++;//after every hit increase the value of the hit counting variable
     
 }

--- a/PadmeReco/RecoBase/src/DigitizerChannelReco.cc
+++ b/PadmeReco/RecoBase/src/DigitizerChannelReco.cc
@@ -11,13 +11,21 @@
 #include <iostream>
 #include <stdlib.h>
 
+static int waveformhit=0;
+int waveformhitmax=10;
+char name[256];
+
 void DigitizerChannelReco::PrintConfig(){
   std::cout << "Signal width: " << fSignalWidth << " samples" << std::endl;
   std::cout << "fUseAbsSignals: " << fUseAbsSignals << std::endl;  
 }
 
 
-DigitizerChannelReco::~DigitizerChannelReco(){;}
+DigitizerChannelReco::~DigitizerChannelReco(){
+  if(fGlobalMode->IsPedestalMode() || fGlobalMode->GetGlobalDebugMode()){
+    SaveDebugHistos();
+  }
+;}
 
 
 void DigitizerChannelReco::Init(GlobalRecoConfigOptions *gMode, PadmeVRecoConfig *cfg){
@@ -27,7 +35,10 @@ void DigitizerChannelReco::Init(GlobalRecoConfigOptions *gMode, PadmeVRecoConfig
   name = cfg->GetParOrDefault("DETECTOR","NAME","DIGI");
   name += "DIGI";
   H1 = new TH1D(name.c_str(),name.c_str(),1000,0.,1000.);
-  //hListCal    = new TList();  // needs to be simplified
+  name = cfg->GetParOrDefault("DETECTOR","NAME","DIGI");
+  name += "2";
+  H2 = new TH1D(name.c_str(),name.c_str(),990,0.,990.);
+    //hListCal    = new TList();  // needs to be simplified
   //hPedCalo = new TH1D*[100];
 
   /*for(int kk=0;kk<100;kk++){
@@ -51,11 +62,13 @@ void DigitizerChannelReco::Init(GlobalRecoConfigOptions *gMode, PadmeVRecoConfig
   fAmpThresholdHigh= cfg->GetParOrDefault("RECO","AmplThrHigh",20.);
 
 
-  fMultihit       = cfg->GetParOrDefault("RECO","Multihit",0); //if MultiHit=1, Peaks finding with TSpectrum
+  fProcessing     = cfg->GetParOrDefault("RECO","Processing",0); //if fProcessing=1, Peaks finding with TSpectrum, if fProcessing=2, RRC processing followed by TSPectrum peak finding
   fUseAbsSignals  = cfg->GetParOrDefault("RECO","UseAbsSignals",0);
 
+  fNewPed  = cfg->GetParOrDefault("RECO","NewPed",1);
+  fTimeCut  = cfg->GetParOrDefault("RECO","TimeCut",0);
 
- fUsePulseProcessing  = cfg->GetParOrDefault("RECO","UsePulseProcessing",1);
+  // fUsePulseProcessing  = cfg->GetParOrDefault("RECO","UsePulseProcessing",1);
  fPeakSearchWidth     = cfg->GetParOrDefault("RECO","PeakSearchWidth",6);
  fZeroSuppression     = cfg->GetParOrDefault("RECO","ZeroSuppression",5.);
  fChargeCut           = cfg->GetParOrDefault("RECO","ChargeCut",0.01);
@@ -68,7 +81,12 @@ void DigitizerChannelReco::Init(GlobalRecoConfigOptions *gMode, PadmeVRecoConfig
 
   std::cout << cfg->GetName() << "*******************************" <<  std::endl;
   PrintConfig();
-  if (fMultihit==0)
+  PrepareTmpHistos();  //Temp histo servono anche in non debug mode
+  if(fGlobalMode->GetGlobalDebugMode() || fGlobalMode->IsPedestalMode()){
+    std::cout<<"preparing debug histos"<<std::endl;
+    PrepareDebugHistos(); //debugging mode histos
+  }
+  if (fProcessing==0)
     {
       if (fabs(fAmpThresholdLow-fAmpThresholdHigh)<0.001)
 	{
@@ -77,6 +95,211 @@ void DigitizerChannelReco::Init(GlobalRecoConfigOptions *gMode, PadmeVRecoConfig
     }
 }
 
+void DigitizerChannelReco::PrepareDebugHistos(){ //Beth 7/6/19 copied from Mauro's DigitizerChannelECal structure to create a set of debug histograms that are produced only in debug mode
+  
+  static char* fileoutname;
+
+  if(fProcessing==0&&fNewPed==0&&fTimeCut==0) fileoutname="RecoAnSingleHitOldPedNoTimeCut.root";
+  if(fProcessing==0&&fNewPed==1&&fTimeCut==0) fileoutname="RecoAnSingleHitNewPedNoTimeCut.root";
+
+  if(fProcessing==0&&fNewPed==0&&fTimeCut==1) fileoutname="RecoAnSingleHitOldPedTimeCut.root";
+  if(fProcessing==0&&fNewPed==1&&fTimeCut==1) fileoutname="RecoAnSingleHitNewPedTimeCut.root";
+
+  if(fProcessing==1) fileoutname="RecoAnMultiHit.root";
+  if(fProcessing==2) fileoutname="RecoAnRCProcessing.root";
+
+  std::cout<<"Created "<<fileoutname<<std::endl;
+
+  fileOut    = new TFile(fileoutname, "RECREATE");
+  
+  fileOut->mkdir("Waveforms");
+  fileOut->mkdir("AmpSpectra");
+  fileOut->mkdir("PedSpectra");
+  fileOut->mkdir("AmpChargeSpectra");
+  fileOut->mkdir("AmpCharge2D");
+  
+  if(fProcessing==2){
+    fileOut->cd("AmpSpectra");
+    gDirectory->mkdir("MultiHit");
+    gDirectory->mkdir("RCProcessed");
+
+    fileOut->cd("AmpChargeSpectra");
+    gDirectory->mkdir("MultiHit");
+    gDirectory->mkdir("RCProcessed");
+    
+    fileOut->cd("AmpCharge2D");
+    gDirectory->mkdir("MultiHit");
+    gDirectory->mkdir("RCProcessed");
+  }
+  
+  hListCal            = new TList(); // single board related histograms  
+  hListWaveform       = new TList(); //Waveform histograms
+  hListAmp            = new TList(); //Amplitude spectra
+  hListPed            = new TList(); //Pedestal spectra
+  hListAmpChargeRatio = new TList(); //Spectra of ratio of amplitude to charge
+  hListAmpCharge2D    = new TList(); //2D amplitude/charge plots
+  
+  //these RC lists are used to store the RC plots. If fProcessing==2 then lists without RC will be multihit.
+  if(fProcessing==2){
+    hListCalRC            = new TList(); // single board related histograms  
+    hListAmpRC            = new TList(); //Amplitude spectra
+    hListAmpChargeRatioRC = new TList(); //Spectra of ratio of amplitude to charge
+    hListAmpCharge2DRC    = new TList(); //2D amplitude/charge plots
+  }
+  
+  Reco = new TTree("RECO","RECO");//Tree variables:
+  Reco->Branch("ElCh",&ElCh);
+  hListTmp->Add(hSat    = new TH1F("hSat","hSat",1000,0.,1000.));
+  
+  //Waveform analysis histograms
+  for(int i =0;i<waveformhitmax;i++){
+    sprintf(name, "hSignal%d", i);
+    hListWaveform->Add(hSignal[i] = new TH1F(name,"Waveform",1024,0.,1024.)); //Signal waveform
+    sprintf(name, "hSignalSmooth%d", i);
+    hListWaveform->Add(hSignalSmooth[i] =  new TH1F(name,"Smoothed Waveform",1024,0,1024));//smoothed waveform
+    sprintf(name, "hdxdt%d", i);
+    hListWaveform->Add(hdxdt[i] = new TH1F(name,"Waveform derivative",1024,0.,1024.)); //Signal derivative
+    sprintf(name, "hdxdtSmooth%d", i);
+    hListWaveform->Add(hdxdtSmooth[i] = new TH1F(name,"Derivative of SignalSmooth",1024,0.,1024.)); //Derivative of smoothed signal
+    sprintf(name, "hdxdtRatio%d", i);
+    hListWaveform->Add(hDerivRatio[i] = new TH1F(name,"Ratio of Derivative to Signal", 1024,0.,1024.));
+    sprintf(name, "hdxdtRatioSmooth%d", i);
+    hListWaveform->Add(hDerivRatioSmooth[i] = new TH1F(name,"Ratio of Derivative to SignalSmooth", 1024,0.,1024.));
+    sprintf(name, "hRCVoltage%d", i);
+    hListWaveform->Add(hRCVoltage[i]= new TH1F(name,"hRCVoltage",1024,0.,1024.));
+  }
+  
+  
+  //More generic histograms to check reconstruction
+  sprintf(name,"charge integrated between %d samples below max signal bin and %d samples above",fPreSamples,fPostSamples);
+  hListCal->Add(hChargeInt = new TH1F(name,"hChargeInt",1000,0.,3500.));
+  
+  if(fProcessing==2){
+    sprintf(name,"charge integrated for RC signals between %d samples below max signal bin and %d samples above",fPreSamples,fPostSamples);
+    hListCalRC->Add(hChargeIntRC = new TH1F(name,"hChargeIntRC",1000,0.,3500.));
+  }
+  
+  for (int i=0; i<96; i++) {  //Here we need one histogram for each channel
+    sprintf(name, "HitAmplitudeChannel%d",i); //This histogram stores the the spectrum of signal amplitudes
+    
+    if(fProcessing==0&&i<82)       hListAmp->Add(hAmpSpectrum[i] = new TH1F(name,"HitAmplitude",100,0.0,2000.0));
+    else if(fProcessing==0&&i>81)  hListAmp->Add(hAmpSpectrum[i] = new TH1F(name,"HitAmplitude",100,0.0,4000.0));
+
+    else if (fProcessing!=0&&i<77) hListAmp->Add(hAmpSpectrum[i] = new TH1F(name,"HitAmplitude",100,0.0,1000.0));
+    else if (fProcessing!=0&&i<82) hListAmp->Add(hAmpSpectrum[i] = new TH1F(name,"HitAmplitude",100,0.0,1500.0));
+    else if (fProcessing!=0&&i>81) hListAmp->Add(hAmpSpectrum[i] = new TH1F(name,"HitAmplitude",100,0.0,4000.0));
+    
+    if(fProcessing==2){
+      sprintf(name, "RCHitAmplitudeChannel%d",i); //This histogram stores the the spectrum of signal amplitudes
+      if(i<77)      hListAmpRC->Add(hAmpSpectrumRC[i] = new TH1F(name,"RCHitAmplitude",100,0.0,300.0));
+      else if(i<87) hListAmpRC->Add(hAmpSpectrumRC[i] = new TH1F(name,"RCHitAmplitude",100,0.0,450.0));
+      else          hListAmpRC->Add(hAmpSpectrumRC[i] = new TH1F(name,"RCHitAmplitude",100,0.0,900.0));
+    }
+    
+    sprintf(name, "HitPedestalChannel%d",i); //This histogram stores the spectrum of hit pedestals
+    hListPed->Add(hPedSpectrum[i] = new TH1F(name,"HitPedestal",100,1500.0,4000.0));
+    
+    sprintf(name, "AmplitudetoChargeRatioChannel%d",i);
+    
+    if(fProcessing==0&&fNewPed==0)        hListAmpChargeRatio->Add(hAmpChargeRatio[i] = new TH1F(name,"AmplitudetoChargeRatio",100,0.0,25000.0));
+    else if(fProcessing==0&&fNewPed==1)   hListAmpChargeRatio->Add(hAmpChargeRatio[i] = new TH1F(name,"AmplitudetoChargeRatio",100,0.0,25000.0));
+    else if (fProcessing!=0){
+      if(i<85) hListAmpChargeRatio->Add(hAmpChargeRatio[i] = new TH1F(name,"AmplitudetoChargeRatio",100,0.0,5.0));
+      else     hListAmpChargeRatio->Add(hAmpChargeRatio[i] = new TH1F(name,"AmplitudetoChargeRatio",100,0.0,3.0));
+      if(fProcessing==2){
+	sprintf(name, "RCAmplitudetoChargeRatioChannel%d",i);
+	if (i<83)  hListAmpChargeRatioRC->Add(hAmpChargeRatioRC[i] = new TH1F(name,"RCAmplitudetoChargeRatio",100,0.0,10.0));
+	else       hListAmpChargeRatioRC->Add(hAmpChargeRatioRC[i] = new TH1F(name,"RCAmplitudetoChargeRatio",100,0.0,6.0));
+      }
+    }
+    
+    sprintf(name, "AmplitudeVsChargeChannel%d",i);
+    if(fProcessing ==0&&i<72)        hListAmpCharge2D->Add(hAmpCharge2D[i] = new TH2F(name,"AmplitudeVsCharge",500,0.,800.,1000.,0.,0.2));
+    else if(fProcessing ==0&&i<83)        hListAmpCharge2D->Add(hAmpCharge2D[i] = new TH2F(name,"AmplitudeVsCharge",500,0.,1500.,1000.,0.,0.2));
+    else if(fProcessing ==0&&i>82)        hListAmpCharge2D->Add(hAmpCharge2D[i] = new TH2F(name,"AmplitudeVsCharge",500,0.,3500.,1000.,0.,0.8));
+
+    else if(fProcessing!=0&&i<73)    hListAmpCharge2D->Add(hAmpCharge2D[i] = new TH2F(name,"AmplitudeVsCharge",500,0.,1100.,1000.,0.,900.));
+    else if(fProcessing!=0&&i<82)    hListAmpCharge2D->Add(hAmpCharge2D[i] = new TH2F(name,"AmplitudeVsCharge",500,0.,1500.,1000.,0.,1500.));
+    else if(fProcessing!=0&&i>81)    hListAmpCharge2D->Add(hAmpCharge2D[i] = new TH2F(name,"AmplitudeVsCharge",500,0.,4000.,1000.,0.,3500.));
+    if(fProcessing==2){
+      sprintf(name, "RCAmplitudeVsChargeChannel%d",i);
+      if(i<65)       hListAmpCharge2DRC->Add(hAmpCharge2DRC[i] = new TH2F(name,"RCAmplitudeVsCharge",500,0.,800.,1000.,0.,150.));
+      else if(i<81)  hListAmpCharge2DRC->Add(hAmpCharge2DRC[i] = new TH2F(name,"RCAmplitudeVsCharge",500,0.,900.,1000.,0.,250.));
+      else           hListAmpCharge2DRC->Add(hAmpCharge2DRC[i] = new TH2F(name,"RCAmplitudeVsCharge",500,0.,900.,1000.,0.,300.));
+    }
+  }
+    
+  hListWaveform->Add(hTrialSignal = new TH1F("hTrialSignal","hTrialSignal",1000,0.,1200.));
+  hListWaveform->Add(hRCProcessedTrialSignal = new TH1F("hRCProcessedTrialSignal","hRCProcessedTrialSignal",1000,0.,1200.));
+  hListWaveform->Add(hSigFinal = new TH1F("hSigFinal","hSigFinal",1000,0.,1000.));
+  hListWaveform->Add(hSigMax = new TH1F("hSigMax","hSigMax",1000,0.,1000.));
+  hListWaveform->Add(hdxdtFinal = new TH1F("hdxdtFinal","hdxdtFinal",1000,0.,1000.));
+  hListWaveform->Add(hdxdtMaxTime= new TH1F("hdxdtMaxTime","hdxdtMaxTime",400,0.,400.));//Time of max derivative
+ 
+}
+
+void DigitizerChannelReco::PrepareTmpHistos(){ //Copied from DigitizerChannelEcal.cc Beth 7/6/2019
+  hListTmp    = new TList();
+  if(!fUseOverSample){
+    hListTmp->Add(hdxdtTmp   = new TH1F("hdxdt","hdxdt",1000,0.,1000.));
+    hListTmp->Add(hSignalTmp = new TH1F("hSignal","hSignal",1000,0.,1000.));
+  }
+  // over sampled histograms
+  Int_t nbinx=4000;
+  if(fUseOverSample){
+    hListTmp->Add(hSigOv       = new TH1F("hSigOv","hSigOv",nbinx,0.,nbinx/4));
+    hListTmp->Add(hSigOvSm     = new TH1F("hSigOvSm","hSigOvSm",nbinx,0.,nbinx/4));
+    hListTmp->Add(hdxdtSigOvSm = new TH1F("hdxdtSigOvSm","hdxdtSigOvSm",nbinx,0.,nbinx/4));
+  } 
+}
+
+void DigitizerChannelReco::SaveDebugHistos(){ //Beth 7/6/19
+  std::cout<<"Save Debug"<<std::endl;
+  fileOut->cd();
+  Reco->Write();
+  hListCal->Write(); //use it in monitor mode only  
+  
+  fileOut->cd("Waveforms");
+  hListWaveform->Write();
+  
+  fileOut->cd("AmpSpectra");
+
+  if(fProcessing!=2)  hListAmp->Write();
+  
+  if(fProcessing==2){
+    gDirectory->cd("MultiHit");
+    hListAmp->Write();
+    gDirectory->cd("../RCProcessed");
+    hListAmpRC->Write();
+  }
+  
+  fileOut->cd("PedSpectra");
+  hListPed->Write();
+  
+  fileOut->cd("AmpChargeSpectra");
+  if(fProcessing!=2)  hListAmpChargeRatio->Write();
+  
+  if(fProcessing==2){
+    gDirectory->cd("MultiHit");
+    hListAmpChargeRatio->Write();
+    gDirectory->cd("../RCProcessed");
+    hListAmpChargeRatioRC->Write();
+  }
+  
+  fileOut->cd("AmpCharge2D");
+  if(fProcessing!=2)  hListAmpCharge2D->Write();
+  
+  if(fProcessing==2){
+    gDirectory->cd("MultiHit");
+    hListAmpCharge2D->Write();
+    gDirectory->cd("../RCProcessed");
+    hListAmpCharge2DRC->Write();
+  }
+
+  // fileOut->Write();
+  //  hListCal->ls();
+  fileOut->Close();
+}
 
 void DigitizerChannelReco::SetAbsSignals(){
   for(UShort_t i = 0;i<fNSamples;i++){
@@ -100,46 +323,45 @@ Short_t DigitizerChannelReco::CalcMaximum() {
 }
 
 
-/*Double_t DigitizerChannelReco::CalcPedestal() {
-  fPed = 0.;
-  fNPedSamples = 0;
-  //Call this only after the maximum is set
-  if(fIMax - fPedOffset < 0) {
-    //What to do if not enough samples for pedestal calculation... 
-    //Use the first few samples
-    fPed = fSamples[0];
-    fNPedSamples = 1;
+Double_t DigitizerChannelReco::CalcPedestal() { //Beth 30/7/19 - one method contains both the "old" and the "new" pedestal calculation so that the pedestal reconstruction method can be chosen by use of the fNewPed flag
+  //"old" pedestal calculation
+  if(fNewPed==0){
+    fPed = 0.;
+    fNPedSamples = 0;
+    //Call this only after the maximum is set
+    if(fIMax - fPedOffset < 0) {
+      //What to do if not enough samples for pedestal calculation... 
+      //Use the first few samples
+      fPed = fSamples[0];
+      fNPedSamples = 1;
+    } 
+    
+    for(Short_t i = fIMax - fPedOffset; 
+	i >= 0 &&  fNPedSamples <  fPedMaxNSamples; 
+	--i,++fNPedSamples) {
+      //    std::cout << i << "  " << fNPedSamples << std::endl;
+      fPed+= fSamples[i];
+    }
+       
+    fPed /= fNPedSamples;
+  }
+ 
+  //"new" pedestal calculation - the pedestal is calculated using the first 200 samples
+  if(fNewPed==1){
+    fPed = 0.;
+    fNPedSamples = 0;
+    fPedMaxNSamples=200;
+    
+    // average of first fPedMaxNSamples
+    for(Short_t i = 0 ; i  <   fPedMaxNSamples; i++) {
+      fNPedSamples ++;
+      fPed+= fSamples[i];
+    }
+    //std::cout << " fNPedSamples " << fNPedSamples <<" fPed Veto"<< std::endl;
+    fPed /= fNPedSamples;
+    //std::cout <<  fPed << " fNPedSamples " << fNPedSamples << std::endl;
+  }
     return fPed;
-  } 
-
-  for(Short_t i = fIMax - fPedOffset; 
-      i >= 0 &&  fNPedSamples <  fPedMaxNSamples; 
-      --i,++fNPedSamples) {
-    //    std::cout << i << "  " << fNPedSamples << std::endl;
-    fPed+= fSamples[i];
-  }
-  
-
-  fPed /= fNPedSamples;
-
-  return fPed;
-}
-*/
-
-Double_t DigitizerChannelReco::CalcPedestal() {  //the pedestal is calculated using the first 200 samples
-  fPed = 0.;
-  fNPedSamples = 0;
-  fPedMaxNSamples=200;
-
-  // average of first fPedMaxNSamples
-  for(Short_t i = 0 ; i  <   fPedMaxNSamples; i++) {
-       fNPedSamples ++;
-       fPed+= fSamples[i];
-  }
-  //std::cout << " fNPedSamples " << fNPedSamples <<" fPed Veto"<< std::endl;
-  fPed /= fNPedSamples;
-  //std::cout <<  fPed << " fNPedSamples " << fNPedSamples << std::endl;
-  return fPed;
 }
 
 Double_t DigitizerChannelReco::ZSupHit(Float_t Thr, UShort_t NAvg) {
@@ -285,18 +507,20 @@ Double_t DigitizerChannelReco::CalcChaTime(std::vector<TRecoVHit *> &hitArray,US
     AbsSamRec[s] = (Double_t) (-1.*fSamples[s]+ped)/4096.*1000.; //in mV positivo
     //std::cout<< s << "     "  << fSamples[s]  <<" V "<< AbsSamRec[s]  <<std::endl;
   }
+
+  if(fProcessing==1)       H1->SetContent(AbsSamRec);
+  else if(fProcessing==2){
+    DigitalProcessingRRC(AbsSamRec,AbsSamRecDP,iMax-1 ,fTimeBin*1e-9);
+    H1->SetContent(AbsSamRecDP);
+  }/* else {
+    H1->SetContent(AbsSamRec);
+    }*/
+
   for(UShort_t s=iMax;s<1024;s++){
     AbsSamRec[s] = 0;
   }
 
   // H1->Reset();
-
-  if (fUsePulseProcessing) {
-    DigitalProcessingRRC(AbsSamRec,AbsSamRecDP,iMax-1 ,fTimeBin*1e-9);
-    H1->SetContent(AbsSamRecDP);
-  } else {
-    H1->SetContent(AbsSamRec);
-  }
 
   // for(UShort_t s = 0;s<256;s++) {
   //   AbsSamRecRebin[s]=0;
@@ -310,6 +534,7 @@ Double_t DigitizerChannelReco::CalcChaTime(std::vector<TRecoVHit *> &hitArray,US
 
   Double_t VMax = H1->GetMaximum();
   Double_t VMin = H1->GetMinimum();
+
   //   std::cout<<"Get Maximum     "<<VMax<<"   Get Minimum    "<<VMin<<std::endl;
   
   //if (VMax>fAmpThresholdHigh) std::cout<<VMax<<" VMax "<<std::endl;
@@ -324,13 +549,13 @@ Double_t DigitizerChannelReco::CalcChaTime(std::vector<TRecoVHit *> &hitArray,US
       fCharge = 0.;
       Double_t xp = (s->GetPositionX())[ll];
       Double_t yp = (s->GetPositionY())[ll];
-      fAmpli=yp;
+      fAmpli1=yp;
       Time=xp*fTimeBin;
       Int_t bin    = H1->GetXaxis()->FindBin(xp);
 
       TRecoVHit *Hit = new TRecoVHit();  
       Hit->SetTime(Time);
-      Hit->SetEnergy(fAmpli);
+      Hit->SetEnergy(fAmpli1);
       hitArray.push_back(Hit);
     }
     //    delete s;
@@ -410,18 +635,280 @@ void DigitizerChannelReco::Reconstruct(std::vector<TRecoVHit *> &hitArray){
     SetAbsSignals();
   }
 
-  if(fMultihit) {
-    ReconstructMultiHit(hitArray);
-  } else {
-    CalcMaximum();
-    //    std::cout<<" fIMax =  "<<fIMax << " Amplitude   " << fPed - fMax <<std::endl;
+
+  if(fGlobalMode->GetGlobalDebugMode() || fGlobalMode->IsPedestalMode()){ //only do histofill in debug mode (therefore only create histograms in debug mode)
+    CalcMaximum(); //returns maximum amplitude of signal (not position of maximum)
     CalcPedestal();
-    //    if(fPed - fMax < fMinAmplitude ) return; //altro taglio da capire fatto in che unita'? conteggi?
+    if(fPed - fMax < fMinAmplitude ) return; //altro taglio da capire fatto in che unita'? conteggi?
+    //std::cout<<"ped = "<<ped<<std::endl;
+    HistoFill();
+  }
+
+  if(fProcessing!=0) {                //if not in single hit mode, run multihit analysis. ReconstructMultiHit includes the RC processing reconstruction code - so if the fProcessing flag ==2 then the RC processing is done there
+    ReconstructMultiHit(hitArray);
+  } 
+  else {                              //if in single hit mode run single hit analysis
+    CalcMaximum();
+    //std::cout<<" fIMax =  "<<fIMax<<std::endl;
+    CalcPedestal();
+    if(fPed - fMax < fMinAmplitude ) return; //altro taglio da capire fatto in che unita'? conteggi?
     ReconstructSingleHit(hitArray);
   }
-  // std::cout << "Maximum: " << fMax << "  at position: "<< fIMax << std::endl;
-  // std::cout << "Pedestal: " << fPed << "  from: " << fNPedSamples << " samples"<< std::endl;
 }
 
 
+void DigitizerChannelReco::HistoFill(){  
+
+  static  Double_t Signal[1024];
+  static  Double_t SmoothedSignal[1024];
+  static Double_t SignalDerivative[1024];
+  static Double_t SignalDerivativeSmoothed[1024];
+  static Double_t DerivativetoSignalRatio[1024];
+  static Double_t DerivativetoSignalRatioSmoothed[1024];
+
+  const Int_t npeaks =50;//maximum number of peaks to be found
+  static Int_t nfound1=-1;
+  static Int_t nfound2=0;
+
+  static Int_t iMax = 1000; //Parsed to DigitalProcessingRRC
+  
+  static Double_t MultiSignal[npeaks];//amplitude of peaks found with TSpectrum
+  static Double_t RCSignal[npeaks];//amplitude of peaks of RC processed signal found with TSpectrum
+
+  static Double_t MultiCharge[npeaks];//amplitude of peaks found with TSpectrum
+  static Double_t RCCharge[npeaks];//amplitude of peaks of RC processed signal found with TSpectrum
+
+  static TSpectrum spMulti(20);
+  static TSpectrum spRC(20);
+  TSpectrum *sMulti = &spMulti; 
+  TSpectrum *sRC = &spRC; 
+    //= new TSpectrum(2*npeaks);  //npeaks max number of peaks
+
+  Int_t    dxdtMaxbin; //bin containing maximum dxdt
+  Double_t sigmax; //maximum signal
+  Int_t    sigmaxbin;  //bin containing maximum signal
+  Double_t ChargeInt =0; //Integral of charge from fPreSamples below max signal to fPostSamples after
+  Double_t ChargeIntRC =0; //Integral of charge from fPreSamples below max signal to fPostSamples after
+
+  int derivbins = 10;
+  int nsmoothing =1;//Number of samples either side used to smooth the signal
+
+  //  std::cout<<"fPed = "<<fPed<<std::endl;
+
+    for(Int_t SignalSample = 0;SignalSample<fNSamples;SignalSample++){
+      Signal[SignalSample]=fPed-(1.*fSamples[SignalSample]);
+      hSigFinal->SetBinContent(SignalSample,Signal[SignalSample]);//used to fill sigmax histo. Overwritten on every loop so will eventually hold the last hit in the last channel
+      hSigMax->Fill(hSigFinal->GetMaximum()/4096*1e3);//in mV
+    } 
+    
+    for(int SmoothSample = 0; SmoothSample < fNSamples; ++SmoothSample){
+      double SignalTot=0;
+      for(int k = -1*nsmoothing;k<nsmoothing+1;k++){
+	if(SmoothSample <nsmoothing||SmoothSample>(fNSamples-nsmoothing)) continue;
+	SignalTot += Signal[SmoothSample+k];
+      }
+      SmoothedSignal[SmoothSample]=SignalTot/(2.*nsmoothing+1.);
+    }
+
+    if (fProcessing!=0){ //Beth 11/7/19 - include TSpectrum processing in Histofill so that you have direct access to variables here, then you can plot things directly, meaning that you can directly compare pre- and post-RC processing 
+
+      double Time1   = 0.; //1 refers to multihi
+      double Time2   = 0.; //2 refers to RC processing
+      Double_t pCMeV= 3.2E5*2*1.67E-7; 
+      Int_t NIntSamp= fSignalWidth/fTimeBin; 
+      
+      Double_t ProcessedAmp[1024];
+      
+      H1->SetContent(Signal);
+      DigitalProcessingRRC(Signal, ProcessedAmp,iMax-1 ,fTimeBin*1e-9);
+      H2->SetContent(ProcessedAmp);
+      
+      Double_t VMax1 = H1->GetMaximum();
+      Double_t VMin1 = H1->GetMinimum();
+      Double_t VMax2 = H2->GetMaximum();
+      Double_t VMin2 = H2->GetMinimum();
+      
+      //if (VMax1>fAmpThresholdHigh) std::cout<<VMax1<<" VMax1 "<<std::endl;
+      //if (VMax2>fAmpThresholdHigh) std::cout<<VMax2<<" VMax2 "<<std::endl;
+      
+      if(VMax1>fAmpThresholdHigh){
+	Double_t peak_thr1  = fAmpThresholdLow/VMax1; //minimum peak height allowed. 
+
+	nfound1 = sMulti->Search(H1,10,"",peak_thr1);     //10 = sigma
+      }
+	
+      if(fProcessing==2&&(VMax2>fAmpThresholdHigh)){
+	Double_t peak_thr2  = fAmpThresholdLow/VMax2; //minimum peak height allowed. 
+	nfound2 = sRC->Search(H2,10,"",peak_thr2);     //10 = sigma
+      }
+      
+      for(Int_t ll=0;ll<nfound1;ll++){ //peak loop per channel
+	fCharge = 0.;
+	//Float_t xp   = xpeaks[ll];
+	Double_t xp = (sMulti->GetPositionX())[ll];
+	//Float_t yp   = ypeaks[ll];
+	Double_t yp = (sMulti->GetPositionY())[ll];
+	fAmpli1=yp;
+	MultiSignal[ll]=fAmpli1;
+	MultiCharge[ll]=TMath::Infinity();
+	
+	Time1=xp*fTimeBin;
+	Int_t bin    = H1->GetXaxis()->FindBin(xp);
+	//	  if(bin<1000){
+	// for (Int_t ii=bin-NIntSamp;ii<bin+NIntSamp;ii++) {
+	if((bin-fPreSamples>0)&&(bin+fPostSamples<fNSamples)){
+	  MultiCharge[ll]=0;
+	  for (Int_t ii=bin-fPreSamples;ii<bin+fPostSamples;ii++) {
+	    //	      if(H1->GetBinContent(ii)>0.005){ 
+	    MultiCharge[ll] += H1->GetBinContent(ii)*1e-3/fImpedance*fTimeBin*1e-9/1E-12;//charge in pC as opposed to for single hit where it's in nC
+	  }
+	}
+      }
+    
+
+      //fEnergy = fCharge/pCMeV;	  
+      if(fProcessing==2){
+	for(Int_t ll=0;ll<nfound2;ll++){ //peak loop per channel
+	  fCharge = 0.;
+	  //Float_t xp   = xpeaks[ll];
+	  Double_t xp = (sRC->GetPositionX())[ll];
+	  //Float_t yp   = ypeaks[ll];
+	  Double_t yp = (sRC->GetPositionY())[ll];
+	  fAmpli2=yp;
+	  RCSignal[ll]=fAmpli2;
+	  RCCharge[ll]=TMath::Infinity();
+	  
+	  Time2=xp*fTimeBin;
+	  Int_t bin    = H2->GetXaxis()->FindBin(xp);
+	  //	    if(bin<1000){
+	  //	      for (Int_t ii=bin-NIntSamp;ii<bin+NIntSamp;ii++) {
+	  if((bin-30>0)&&(bin+30<fNSamples)){
+	    RCCharge[ll]=0;
+	    for (Int_t ii=bin-30;ii<bin+30;ii++) {
+	      //	      if(H2->GetBinContent(ii)>0.005){ 
+	      RCCharge[ll] += H2->GetBinContent(ii)*1e-3/fImpedance*fTimeBin*1e-9/1E-12;//charge in pC as opposed to for single hit where it's in nC
+	    }
+	  }
+	  //fEnergy = fCharge/pCMeV;	  
+	}
+      }
+    }
+    //    }
+    //}
+    
+
+
+    //Beth 17/6/19 to try to optimise R1, R2, C, we create a sample input signal with form exp(-t/20.5), where 20.5 has been found by using root to fit the exponential tale of a signal
+
+    Double_t TrialSamp[1024];
+
+    for(int itri=0;itri<1024;itri++){
+      if(itri>200){
+	TrialSamp[itri]=100*exp(-(itri-200)*fTimeBin/20.5);
+      }
+      else{TrialSamp[itri]=0;}
+    }
+
+    Double_t TrialOut[fNSamples];
+    Double_t SignalOut[fNSamples];
+    
+    DigitalProcessingRRC(TrialSamp, TrialOut, iMax-1, fTimeBin*1e-9);
+    DigitalProcessingRRC(Signal, SignalOut, iMax-1, fTimeBin*1e-9);
+      
+    for(int iSample = 0; iSample < fNSamples; ++iSample){
+      //std::cout<<"iSample = "<<iSample<<std::endl;
+      SignalDerivative[iSample] = 0;
+      if(iSample>=derivbins&&iSample<fNSamples){ //otherwise the derivative doesn't make sense - you can't calculate the derivative of the first bin because you have nothing before it to compare it to
+	//	SignalDerivative[iSample] = (Signal[iSample+derivbins]-Signal[iSample-derivbins])/((2*derivbins)*fTimeBin); //fTimeBin = time between samples.
+	SignalDerivative[iSample] = (Signal[iSample]-Signal[iSample-derivbins])/((derivbins)*fTimeBin); //Calculating the derivative only backwards gives the highest possible value for the derivative as it isn't confused by the peak
+	hdxdtFinal->SetBinContent(iSample, SignalDerivative[iSample]);
+      }
+      SignalDerivativeSmoothed[iSample] =0;
+      if(iSample>=derivbins&&iSample<fNSamples){
+	//	  SignalDerivativeSmoothed[iSample] = (SmoothedSignal[iSample+derivbins]-SmoothedSignal[iSample-derivbins])/((2*derivbins)*fTimeBin);
+	SignalDerivativeSmoothed[iSample] = (SmoothedSignal[iSample]-SmoothedSignal[iSample-derivbins])/((derivbins)*fTimeBin);
+      }
+      DerivativetoSignalRatio[iSample] = SignalDerivative[iSample]/Signal[iSample];
+      DerivativetoSignalRatioSmoothed[iSample] = SignalDerivativeSmoothed[iSample]/SmoothedSignal[iSample];
+    }
+    
+    
+    dxdtMaxbin = hdxdtFinal->TH1::GetMaximumBin();//Returns bin number of bin of maximum content - that is the location of the histogram peak
+    hdxdtMaxTime->Fill(dxdtMaxbin*fTimeBin);//Converts bin number to time
+    
+    sigmaxbin = hSigFinal->TH1::GetMaximumBin();
+  
+    Int_t begin = sigmaxbin-10>0? sigmaxbin-10:0;//if(sigmaxbin-10)>0, begin=sigmaxbun-10, else begin = 0
+    Int_t end = sigmaxbin+150>fNSamples? sigmaxbin+150:fNSamples;
+
+    for(int i=begin;i<end;i++){
+      if(fProcessing==0)    ChargeInt+=Signal[i]/(4096*fImpedance)*fTimeBin*1e-9/1E-12; //in pC
+      else{
+	ChargeInt+=fAmpli1/(4096*fImpedance)*fTimeBin*1e-9/1E-12; //in pC
+	ChargeIntRC+=fAmpli2/(4096*fImpedance)*fTimeBin*1e-9/1E-12; //in pC
+      }
+    }
+    hChargeInt->Fill(ChargeInt);
+    
+    //  if(fProcessing==1&&fNewPed==1&&(TMath::MaxElement(fNSamples,Signal)/fCharge)>25) std::cout<<"GetChID() "<<GetChID()<<" TMath::MaxElement(fNSamples,Signal)/fCharge = "<<TMath::MaxElement(fNSamples,Signal)/fCharge<<std::endl;
+    if(fProcessing==0){
+      if(fTimeCut==1){ //If we're using the time cut...
+	if(CalcTime(fIMax)>10.) { //use the time cut
+	  hPedSpectrum[GetChID()]->Fill(fPed);
+	  hAmpSpectrum[GetChID()]->Fill(TMath::MaxElement(fNSamples,Signal));
+	  hAmpChargeRatio[GetChID()]->Fill(TMath::MaxElement(fNSamples,Signal)/fCharge);
+	  hAmpCharge2D[GetChID()]->Fill(TMath::MaxElement(fNSamples,Signal),fCharge);
+	}
+      }
+
+      else if (fTimeCut==0){ //Otherwise, if we're not using the time cut, fill the histograms anyway
+	hPedSpectrum[GetChID()]->Fill(fPed);
+	hAmpSpectrum[GetChID()]->Fill(TMath::MaxElement(fNSamples,Signal));
+	hAmpChargeRatio[GetChID()]->Fill(TMath::MaxElement(fNSamples,Signal)/fCharge);
+	//      if(((GetChID()==60||GetChID()==71)&&fCharge>500)||(GetChID()==80&&fCharge>1500)||(GetChID()==87&&fCharge>3500))      std::cout<<"GetChID() "<<GetChID()<<" amp = "<<TMath::MaxElement(fNSamples,Signal)<<" charge = "<<fCharge<<std::endl;
+	hAmpCharge2D[GetChID()]->Fill(TMath::MaxElement(fNSamples,Signal),fCharge);
+      }
+    }
+
+    else{
+      hPedSpectrum[GetChID()]->Fill(fPed);
+      //      std::cout<<"nfound1 = "<<nfound1<<std::endl;
+      for(int i = 0;i<nfound1;i++){
+	hAmpSpectrum[GetChID()]->Fill(MultiSignal[i]);
+	if(MultiCharge[i]<TMath::Infinity()){
+	  hAmpChargeRatio[GetChID()]->Fill(MultiSignal[i]/MultiCharge[i]);
+	  hAmpCharge2D[GetChID()]->Fill(MultiSignal[i],MultiCharge[i]);
+	}
+      }
+
+      if(fProcessing==2){
+	for(int i = 0;i<nfound2;i++){
+	  hAmpSpectrumRC[GetChID()]->Fill(RCSignal[i]);
+	  if(RCCharge[i]<TMath::Infinity()){
+	    hAmpChargeRatioRC[GetChID()]->Fill(RCSignal[i]/RCCharge[i]);
+	    hAmpCharge2DRC[GetChID()]->Fill(RCSignal[i],RCCharge[i]);
+	  }
+	}
+      }
+    }
+
+    if(waveformhit<waveformhitmax){
+      //    std::cout<<"waveformhit = " << waveformhit << " GetChID() = " <<GetChID()<<std::endl;
+      for(int i=0;i<fNSamples;i++){
+	hSignal[waveformhit]->SetBinContent(i,Signal[i]);
+	hSignalSmooth[waveformhit]->SetBinContent(i,SmoothedSignal[i]);
+	hdxdt[waveformhit]->SetBinContent(i, SignalDerivative[i]);
+	hdxdtSmooth[waveformhit]->SetBinContent(i, SignalDerivativeSmoothed[i]);
+	hDerivRatio[waveformhit]->SetBinContent(i,DerivativetoSignalRatio[i]);
+	hDerivRatioSmooth[waveformhit]->SetBinContent(i,DerivativetoSignalRatioSmoothed[i]);
+	hRCVoltage[waveformhit]->SetBinContent(i+1, SignalOut[i]);
+	hTrialSignal->SetBinContent(i,TrialSamp[i]);
+	hRCProcessedTrialSignal->SetBinContent(i,TrialOut[i]);
+      }
+    }
+    
+    if(waveformhit==0) std::cout<<"parameters are: fProcessing = "<<fProcessing<<" fNewPed = "<<fNewPed<<" fTimeCut = "<<fTimeCut<<std::endl;
+    waveformhit++;//after every hit increase the value of the hit counting variable
+    
+}
 

--- a/PadmeReco/config/EVeto.cfg
+++ b/PadmeReco/config/EVeto.cfg
@@ -22,12 +22,14 @@ SignalPreSamples		30
 SignalPostSamples		120
 PedestalOffset     		50
 NumberOfSamplesPedestal		50
-#Multihit [0- SingleHit, 1- Multihit with TSpectrum]
-Multihit			1
+#Processing [0- SingleHit, 1- Multihit with TSpectrum, 2- RC processing followed by TSpectrum]
+Processing			2
 #MinAmplitude			40
 MinAmplitude			20
 AmplThrLow			10
 AmplThrHigh			20
+NewPed                          1 #use pedestals from samples before maximum amplitude or from first 200 samples? 0 = around max, 1 = first 200
+TimeCut				0
 
 
 [RECOCLUSTER]

--- a/PadmeReco/config/HEPVeto.cfg
+++ b/PadmeReco/config/HEPVeto.cfg
@@ -22,12 +22,14 @@ SignalPreSamples		30
 SignalPostSamples		150
 PedestalOffset     		50
 NumberOfSamplesPedestal		50
-#Multihit [0- SingleHit, 1- Multihit with TSpectrum]
-Multihit			1
+#Processing [0- SingleHit, 1- Multihit with TSpectrum, 2- RC processing followed by TSpectrum]
+Processing			2
 #MinAmplitude			30
 MinAmplitude			20
 AmplThrLow			10
 AmplThrHigh			20
+NewPed                          1 #use pedestals from samples before maximum amplitude or from first 200 samples? 0 = around max, 1 = first 200
+TimeCut				0
 
 [RECOCLUSTER]
 ClusterDeltaTimeMax            5.

--- a/PadmeReco/config/PVeto.cfg
+++ b/PadmeReco/config/PVeto.cfg
@@ -17,117 +17,24 @@ InputImpedance	50
 VoltageBin	0.000244
 
 [RECO]
-SignalWindow                   151
-SignalPreSamples               30
-SignalPostSamples              120
+SignalWindow       		151
+SignalPreSamples		30
+SignalPostSamples		120
 PedestalOffset     		50
-NumberOfSamplesPedestal		50
-#Multihit [0- SingleHit, 1- Multihit with TSpectrum]
-Multihit			1
+NumberOfSamplesPedestal		50  
+#Processing [0- SingleHit, 1- Multihit with TSpectrum, 2- RC processing followed by TSpectrum]
+Processing			2
+#MinAmplitude used ony in single hit mode 
 MinAmplitude			20
+#if Processing==0, AmplThrLow and AmplThrHigh must be different 
 AmplThrLow			10
 AmplThrHigh			20
-
+NewPed                          1 #use pedestals from samples before maximum amplitude or from first 200 samples? 0 = around max, 1 = first 200
+TimeCut			0
 
 
 [TimeCalibration]
-Common_t0  0.
-t0_0  0.
-t0_1  -0.310172
-t0_2  0.121249
-t0_3  -0.247052
-t0_4  -0.157618
-t0_5  -0.293280
-t0_6  -0.118991
-t0_7  0.212889
-t0_8  -0.107553
-t0_9  -0.369732
-t0_10  0.168284
-t0_11  -0.010661
-t0_12  -0.067076
-t0_13  -0.452233
-t0_14  -0.283537
-t0_15  -0.224673
-t0_16  -0.232714
-t0_17  -0.603791
-t0_18  -0.264062
-t0_19  -0.560891
-t0_20  -0.449292
-t0_21  -0.642559
-t0_22  -0.693545
-t0_23  -0.660729
-t0_24  -0.999697
-t0_25  -1.354069
-t0_26  -1.425558
-t0_27  -1.449183
-t0_28  -1.725291
-t0_29  -1.560595
-t0_30  -1.747452
-t0_31  -2.214123
-t0_32  -2.080246
-t0_33  -2.222488
-t0_34  -2.309014
-t0_35  -2.319049
-t0_36  -2.979443
-t0_37  -2.885076
-t0_38  -2.793347
-t0_39  -2.737924
-t0_40  -3.070128
-t0_41  -3.339260
-t0_42  -3.462260
-t0_43  -3.408190
-t0_44  -3.590468
-t0_45  -3.807832
-t0_46  -3.626128
-t0_47  -3.435587
-t0_48  -6.660007
-t0_49  -6.688598
-t0_50  -6.313409
-t0_51  -6.750271
-t0_52  -6.714454
-t0_53  -6.623679
-t0_54  -6.670201
-t0_55  -6.691846
-t0_56  -7.139451
-t0_57  -7.493685
-t0_58  -6.984883
-t0_59  -7.633519
-t0_60  -7.421703
-t0_61  -7.737984
-t0_62  -7.571681
-t0_63  -7.934764
-t0_64  -8.512551
-t0_65  -8.563825
-t0_66  -8.496834
-t0_67  -8.811448
-t0_68  -8.866688
-t0_69  -8.494397
-t0_70  -8.434211
-t0_71  -8.080711
-t0_72  -9.043618
-t0_73  -9.419362
-t0_74  -9.797722
-t0_75  -10.041366
-t0_76  -10.268302
-t0_77  -10.277800
-t0_78  -10.179073
-t0_79  -10.025416
-t0_80  -11.126344
-t0_81  -11.034357
-t0_82  -11.042541
-t0_83  -11.557363
-t0_84  -11.602454
-t0_85  -11.471241
-t0_86  -11.913219
-t0_87  -12.477117
-t0_88  -13.625404
-t0_89  -15.134064
-t0_90  -13.072010
-t0_91  -8.477386
-t0_92  -8.477386
-t0_93  -8.477386
-t0_94  -8.477386
-t0_95  -8.477386
+0   7.3
 
 
 [ChargeCalibration]
@@ -139,37 +46,10 @@ ClusterDeltaTimeMax            5.
 ClusterDeltaCellMax            2
 ClusterEnergyThresholdForHit   2.
 ClusterEnergyThresholdForSeed  3.
-ClusterTLowForHit              -100.
-#ClusterTHighForHit              180.
-ClusterTHighForHit              300.
+ClusterTLowForHit              -500.
+ClusterTHighForHit              500.
+#ClusterTHighForHit              300.
 
 [Output]
 Hits            1
 Clusters        1
-
-
-[GEOMETRY]
-ComputeFromPrimaryNumbers 1
-LocalOrigineX    182.5
-LocalOrigineY    0.
-LocalOrigineZ    0. 
-LocalAngleXPadmeFrame 0.
-LocalAngleYPadmeFrame 0.
-LocalAngleZPadmeFrame 0.
-Step1LocalX 0.
-Step1LocalY 0.
-Step1LocalZ 11.
-ChId@LocalX0 0.
-ChId@LocalY0 0.
-#ChId@LocalZ0 48.
-ChId@LocalZ0 0.
-ChId@LocalX0Offset 0.
-ChId@LocalY0Offset 0.
-#ChId@LocalZ0Offset 0.
-ChId@LocalZ0Offset -472.55
-#in line with MC Geometry
-FingerSizeX  10.
-FingerSizeY  178.
-FingerSizeZ  10.
-PVetoInnerFacePosX  177.5 
-PVetoFrontFacePosZ -472.55

--- a/PadmeReco/config/PVeto.cfg
+++ b/PadmeReco/config/PVeto.cfg
@@ -30,11 +30,107 @@ MinAmplitude			20
 AmplThrLow			10
 AmplThrHigh			20
 NewPed                          1 #use pedestals from samples before maximum amplitude or from first 200 samples? 0 = around max, 1 = first 200
-TimeCut			0
+TimeCut				0
 
 
 [TimeCalibration]
-0   7.3
+Common_t0  0.
+t0_0  0.
+t0_1  -0.310172
+t0_2  0.121249
+t0_3  -0.247052
+t0_4  -0.157618
+t0_5  -0.293280
+t0_6  -0.118991
+t0_7  0.212889
+t0_8  -0.107553
+t0_9  -0.369732
+t0_10  0.168284
+t0_11  -0.010661
+t0_12  -0.067076
+t0_13  -0.452233
+t0_14  -0.283537
+t0_15  -0.224673
+t0_16  -0.232714
+t0_17  -0.603791
+t0_18  -0.264062
+t0_19  -0.560891
+t0_20  -0.449292
+t0_21  -0.642559
+t0_22  -0.693545
+t0_23  -0.660729
+t0_24  -0.999697
+t0_25  -1.354069
+t0_26  -1.425558
+t0_27  -1.449183
+t0_28  -1.725291
+t0_29  -1.560595
+t0_30  -1.747452
+t0_31  -2.214123
+t0_32  -2.080246
+t0_33  -2.222488
+t0_34  -2.309014
+t0_35  -2.319049
+t0_36  -2.979443
+t0_37  -2.885076
+t0_38  -2.793347
+t0_39  -2.737924
+t0_40  -3.070128
+t0_41  -3.339260
+t0_42  -3.462260
+t0_43  -3.408190
+t0_44  -3.590468
+t0_45  -3.807832
+t0_46  -3.626128
+t0_47  -3.435587
+t0_48  -6.660007
+t0_49  -6.688598
+t0_50  -6.313409
+t0_51  -6.750271
+t0_52  -6.714454
+t0_53  -6.623679
+t0_54  -6.670201
+t0_55  -6.691846
+t0_56  -7.139451
+t0_57  -7.493685
+t0_58  -6.984883
+t0_59  -7.633519
+t0_60  -7.421703
+t0_61  -7.737984
+t0_62  -7.571681
+t0_63  -7.934764
+t0_64  -8.512551
+t0_65  -8.563825
+t0_66  -8.496834
+t0_67  -8.811448
+t0_68  -8.866688
+t0_69  -8.494397
+t0_70  -8.434211
+t0_71  -8.080711
+t0_72  -9.043618
+t0_73  -9.419362
+t0_74  -9.797722
+t0_75  -10.041366
+t0_76  -10.268302
+t0_77  -10.277800
+t0_78  -10.179073
+t0_79  -10.025416
+t0_80  -11.126344
+t0_81  -11.034357
+t0_82  -11.042541
+t0_83  -11.557363
+t0_84  -11.602454
+t0_85  -11.471241
+t0_86  -11.913219
+t0_87  -12.477117
+t0_88  -13.625404
+t0_89  -15.134064
+t0_90  -13.072010
+t0_91  -8.477386
+t0_92  -8.477386
+t0_93  -8.477386
+t0_94  -8.477386
+t0_95  -8.477386
 
 
 [ChargeCalibration]
@@ -46,10 +142,37 @@ ClusterDeltaTimeMax            5.
 ClusterDeltaCellMax            2
 ClusterEnergyThresholdForHit   2.
 ClusterEnergyThresholdForSeed  3.
-ClusterTLowForHit              -500.
-ClusterTHighForHit              500.
-#ClusterTHighForHit              300.
+ClusterTLowForHit              -100.
+#ClusterTHighForHit              180.
+ClusterTHighForHit              300.
 
 [Output]
 Hits            1
 Clusters        1
+
+
+[GEOMETRY]
+ComputeFromPrimaryNumbers 1
+LocalOrigineX    182.5
+LocalOrigineY    0.
+LocalOrigineZ    0. 
+LocalAngleXPadmeFrame 0.
+LocalAngleYPadmeFrame 0.
+LocalAngleZPadmeFrame 0.
+Step1LocalX 0.
+Step1LocalY 0.
+Step1LocalZ 11.
+ChId@LocalX0 0.
+ChId@LocalY0 0.
+#ChId@LocalZ0 48.
+ChId@LocalZ0 0.
+ChId@LocalX0Offset 0.
+ChId@LocalY0Offset 0.
+#ChId@LocalZ0Offset 0.
+ChId@LocalZ0Offset -472.55
+#in line with MC Geometry
+FingerSizeX  10.
+FingerSizeY  178.
+FingerSizeZ  10.
+PVetoInnerFacePosX  177.5 
+PVetoFrontFacePosZ -472.55

--- a/PadmeReco/config/PVeto.cfg
+++ b/PadmeReco/config/PVeto.cfg
@@ -4,7 +4,7 @@ NCHANNELS    96
 READOUT      ADC
 
 
-[ADC]
+[ADC]1
 NADC  3
 ID    10 11 12
 #Format of the next lines: ADC$ID - list of channels


### PR DESCRIPTION
Implemented in DigitizerChannelReco.cc a series of histograms useful for debugging the PVeto. Modified PVeto.cfg to allow for either Single hit/Multi hit/RRC Processed + TSpectrum reconstruction, and to allow investigation of a time cut & different forms of pedestal reconstruction. Modified PVetoReconstruction.cc to allow for board & channel id information in DigitizerChannelReco.cc to allow channel-by-channel debugging.