### PR TITLE
Auto elog messages from RunControl

### DIFF
--- a/RunControl/code/RunControlServer.py
+++ b/RunControl/code/RunControlServer.py
@@ -8,6 +8,7 @@ import signal
 from Run     import Run
 from Logger  import Logger
 from PadmeDB import PadmeDB
+from elog_notify import ElogNotify
 
 class RunControlServer:
 
@@ -16,6 +17,8 @@ class RunControlServer:
         # Define names of lock and last_used_setup files
         self.lock_file = "run/lock"
         self.lus_file = "setup/last_used_setup"
+
+        self.elog = ElogNotify('http://padmesrv2.lnf.infn.it:8080/')
 
         # Redefine print to send output to log file
         sys.stdout = Logger()
@@ -675,6 +678,19 @@ exit\t\tTell RunControl server to exit (use with extreme care!)"""
         open(self.run.start_file,'w').close()
 
         self.send_answer("run_started")
+        self.elog.log_message('Run',
+            Author='RunControl',
+            Subsystem='Run',
+            Category='General',
+            Subject='Started run %d'%self.run.run_number,
+            Text='\n'.join([
+                'New run started',
+                'Run number:  %d'%self.run.run_number,
+                'Run type:    %s'%self.run.run_type,
+                'Run crew:    %s'%self.run.run_user,
+                'Run comment: %s'%self.run.run_comment_start,
+                ])
+            )
 
         # RunControl is now in "running" mode
         return "running"
@@ -712,6 +728,21 @@ exit\t\tTell RunControl server to exit (use with extreme care!)"""
 
         # Create "stop the run" tag file
         open(self.run.quit_file,'w').close()
+
+        self.elog.log_message('Run',
+            Author='RunControl',
+            Subsystem='Run',
+            Category='General',
+            Subject='Terminated run %d'%self.run.run_number,
+            Text='\n'.join([
+                'Run terminated',
+                'Run number:    %d'%self.run.run_number,
+                'Run type:      %s'%self.run.run_type,
+                'Run crew:      %s'%self.run.run_user,
+                'Start message: %s'%self.run.run_comment_start,
+                'Stop message:  %s'%self.run.run_comment_stop,
+                ])
+            )
 
         # Run stop_daq procedure for each ADC board
         terminate_ok = True

--- a/RunControl/code/elog_notify.py
+++ b/RunControl/code/elog_notify.py
@@ -1,0 +1,31 @@
+import requests
+
+class ElogNotify:
+    def __init__(self, url):
+        self.url = url
+    def log_message(self, logbook, **kwargs):
+        print(kwargs)
+        fields = dict(kwargs)
+        fields.update(cmd='Submit')
+        try:
+            requests.post(self.url+logbook, files=fields, timeout=.00001)
+        except:
+            pass
+
+
+if __name__ == '__main__':
+    elog = ElogNotify('http://127.0.0.1:8080/')
+    elog.log_message('Run',
+        Author='RunControl',
+        Subsystem='Run',
+        Category='General',
+        Subject='Terminated run %d'%209384092,
+        Text='\n'.join([
+            'Run terminated',
+            'Run number:    %d'%209384092,
+            'Run type:      %s'%'self.run.run_type',
+            'Run crew:      %s'%'self.run.run_user',
+            'Start message: %s'%'self.run.run_comment_start',
+            'Stop message:  %s'%'self.run.run_comment_stop',
+            ])
+        )


### PR DESCRIPTION
Send automatic messages in the e-log when a run is started or stopped. The changes are not tested as we do not have a test bench. Please test before deploy